### PR TITLE
:]

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,3 @@
-github "ReactiveCocoa/ReactiveSwift" "1.1.1"
+github "ReactiveCocoa/ReactiveSwift" "2.0.0-rc.3"
 github "ReactiveX/RxSwift" "3.4.0"
 github "ReactiveKit/ReactiveKit" "v3.5.3"

--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,4 @@
 github "ReactiveCocoa/ReactiveSwift" "2.0.0-rc.3"
 github "ReactiveX/RxSwift" "3.4.0"
 github "ReactiveKit/ReactiveKit" "v3.5.3"
+github "mattgallagher/CwlSignal" "2.0.0-beta.25"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
-github "ReactiveCocoa/ReactiveSwift" "1.1.1"
+github "ReactiveCocoa/ReactiveSwift" "2.0.0-rc.3"
 github "ReactiveKit/ReactiveKit" "v3.5.3"
 github "ReactiveX/RxSwift" "3.4.0"
-github "antitypical/Result" "3.2.1"
+github "antitypical/Result" "3.2.3"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,6 @@
+git "https://github.com/mattgallagher/CwlUtils.git" "3b6906601ab5f5b37c5d6178edc2b09a7e36da12"
 github "ReactiveCocoa/ReactiveSwift" "2.0.0-rc.3"
 github "ReactiveKit/ReactiveKit" "v3.5.3"
 github "ReactiveX/RxSwift" "3.4.0"
 github "antitypical/Result" "3.2.3"
+github "mattgallagher/CwlSignal" "2.0.0-beta.25"

--- a/TestingFRP.xcodeproj/project.pbxproj
+++ b/TestingFRP.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		9A99B0EF1F1A0B7F002299DC /* CwlSignal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A99B0ED1F1A0B7F002299DC /* CwlSignal.framework */; };
+		9A99B0F01F1A0B7F002299DC /* CwlUtils.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A99B0EE1F1A0B7F002299DC /* CwlUtils.framework */; };
 		B23DE9A51EB3D985005C13E2 /* TestingFRP.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B23DE99B1EB3D985005C13E2 /* TestingFRP.framework */; };
 		B23DE9AA1EB3D985005C13E2 /* TestingFRPTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B23DE9A91EB3D985005C13E2 /* TestingFRPTests.swift */; };
 		B23DE9AC1EB3D985005C13E2 /* TestingFRP.h in Headers */ = {isa = PBXBuildFile; fileRef = B23DE99E1EB3D985005C13E2 /* TestingFRP.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -27,6 +29,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		9A99B0ED1F1A0B7F002299DC /* CwlSignal.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CwlSignal.framework; path = Carthage/Build/iOS/CwlSignal.framework; sourceTree = "<group>"; };
+		9A99B0EE1F1A0B7F002299DC /* CwlUtils.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CwlUtils.framework; path = Carthage/Build/iOS/CwlUtils.framework; sourceTree = "<group>"; };
 		B23DE99B1EB3D985005C13E2 /* TestingFRP.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TestingFRP.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B23DE99E1EB3D985005C13E2 /* TestingFRP.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TestingFRP.h; sourceTree = "<group>"; };
 		B23DE99F1EB3D985005C13E2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -48,6 +52,8 @@
 				B23DE9B91EB3DBEB005C13E2 /* ReactiveSwift.framework in Frameworks */,
 				B23DE9BA1EB3DBEB005C13E2 /* Result.framework in Frameworks */,
 				B23DE9BB1EB3DBEB005C13E2 /* RxSwift.framework in Frameworks */,
+				9A99B0EF1F1A0B7F002299DC /* CwlSignal.framework in Frameworks */,
+				9A99B0F01F1A0B7F002299DC /* CwlUtils.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -102,6 +108,8 @@
 		B23DE9B51EB3DBEA005C13E2 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				9A99B0ED1F1A0B7F002299DC /* CwlSignal.framework */,
+				9A99B0EE1F1A0B7F002299DC /* CwlUtils.framework */,
 				B2DCA7291EB4C78F00DA863B /* ReactiveKit.framework */,
 				B23DE9B61EB3DBEB005C13E2 /* ReactiveSwift.framework */,
 				B23DE9B71EB3DBEB005C13E2 /* Result.framework */,

--- a/TestingFRPTests/TestingFRPTests.swift
+++ b/TestingFRPTests/TestingFRPTests.swift
@@ -3,6 +3,7 @@ import enum Result.NoError
 import ReactiveSwift
 import RxSwift
 import ReactiveKit
+import CwlSignal
 @testable import TestingFRP
 
 class TestingFRPTests: XCTestCase {
@@ -49,6 +50,21 @@ class TestingFRPTests: XCTestCase {
             }
 
             _ = signal.observeNext(with: { counter += $0 })
+        }
+    }
+
+    func test_measure_CwlSignal_1() {
+        measure {
+            var counter : Int = 0
+            let signal = CwlSignal.Signal<Int>.generate { input in
+                if let input = input {
+                    for i in 1..<100_000 {
+                        input.send(value: i)
+                    }
+                }
+            }
+
+            _ = signal.subscribeValues { counter += $0 }
         }
     }
 
@@ -99,6 +115,28 @@ class TestingFRPTests: XCTestCase {
         }
     }
 
+    func test_measure_CwlSignal_2() {
+        // CwlSignal does not have a `Property` entity, so we use its `replayLast`
+        // counterpart.
+        measure {
+            var endpoints: [AnyObject] = []
+            var counter : Int = 0
+            let (input, output) = CwlSignal.Signal<Int>.create { $0.continuous() }
+
+            let multicasted = output.multicast()
+            for _ in 1..<100 {
+                let e = multicasted.subscribeValues { counter += $0 }
+                endpoints.append(e)
+            }
+
+            withExtendedLifetime(endpoints) {
+                for i in 1..<100_000 {
+                    input.send(value: i)
+                }
+            }
+        }
+    }
+
     /// ===============================================================
 
     func test_measure_ReactiveSwift_3() {
@@ -106,7 +144,7 @@ class TestingFRPTests: XCTestCase {
             let (signal, observer) = ReactiveSwift.Signal<Int, NoError>.pipe()
 
             for _ in 1..<100 {
-                signal.filter{ $0%2 == 0}.map(String.init).observeValues { _ in }
+                signal.filterMap { $0 % 2 == 0 ? String($0) : nil }.observeValues { _ in }
             }
 
             for i in 1..<100_000 {
@@ -123,13 +161,31 @@ class TestingFRPTests: XCTestCase {
             for _ in 1..<100 {
                 _ = o.filter{ $0%2 == 0}.map(String.init).subscribe(onNext: { _ in })
             }
-            
+
             for i in 1..<100_000 {
                 variable.onNext(i)
             }
         }
     }
 
+    func test_measure_CwlSignal_3() {
+        measure {
+            var endpoints: [AnyObject] = []
+            let (input, output) = CwlSignal.Signal<Int>.create()
+            let multicasted = output.multicast()
+
+            for _ in 1..<100 {
+                let e = multicasted.filterMap { $0 % 2 == 0 ? String($0) : nil }.subscribeValues { _ in }
+                endpoints.append(e)
+            }
+
+            withExtendedLifetime(endpoints) {
+                for i in 1..<100_000 {
+                    input.send(value: i)
+                }
+            }
+        }
+    }
 
     /// ===============================================================
 
@@ -171,4 +227,26 @@ class TestingFRPTests: XCTestCase {
         }
     }
 
+    func test_measure_CwlSignal_4() {
+        measure {
+            var endpoints: [AnyObject] = []
+
+            let (input1, output1) = CwlSignal.Signal<Int>.create()
+            let (input2, output2) = CwlSignal.Signal<Int>.create()
+            let multicasted1 = output1.multicast()
+            let multicasted2 = output2.multicast()
+
+            for _ in 1..<100 {
+                let e = multicasted1.combineLatest(second: multicasted2) { $0 }.subscribeValues { _ in }
+                endpoints.append(e)
+            }
+
+            withExtendedLifetime(endpoints) {
+                for i in 1..<100_000 {
+                    input1.send(value: i)
+                    input2.send(value: i)
+                }
+            }
+        }
+    }
 }

--- a/TestingFRPTests/TestingFRPTests.swift
+++ b/TestingFRPTests/TestingFRPTests.swift
@@ -57,14 +57,14 @@ class TestingFRPTests: XCTestCase {
     func test_measure_ReactiveSwift_2() {
         measure {
             var counter : Int = 0
-            let (signal, observer) = ReactiveSwift.Signal<Int, NoError>.pipe()
+            let property = ReactiveSwift.MutableProperty<Int>(0)
 
             for _ in 1..<100 {
-                signal.observeValues { counter += $0 }
+                property.producer.startWithValues { counter += $0 }
             }
 
             for i in 1..<100_000 {
-                observer.send(value: i)
+                property.value = i
             }
         }
     }
@@ -117,7 +117,7 @@ class TestingFRPTests: XCTestCase {
 
     func test_measure_RxSwift_3() {
         measure {
-            let variable = Variable(0)
+            let variable = RxSwift.PublishSubject<Int>()
             let o = variable.asObservable()
 
             for _ in 1..<100 {
@@ -125,7 +125,7 @@ class TestingFRPTests: XCTestCase {
             }
             
             for i in 1..<100_000 {
-                variable.value = i
+                variable.onNext(i)
             }
         }
     }
@@ -153,8 +153,8 @@ class TestingFRPTests: XCTestCase {
 
     func test_measure_RxSwift_4() {
         measure {
-            let v1 = Variable(0)
-            let v2 = Variable(0)
+            let v1 = RxSwift.PublishSubject<Int>()
+            let v2 = RxSwift.PublishSubject<Int>()
 
             let o1 = v1.asObservable()
             let o2 = v2.asObservable()
@@ -165,8 +165,8 @@ class TestingFRPTests: XCTestCase {
             }
 
             for i in 1..<1_000 {
-                v1.value = i
-                v2.value = i
+                v1.onNext(i)
+                v2.onNext(i)
             }
         }
     }


### PR DESCRIPTION
`Variable` should be matched with `MutableProperty`, and `Signal` should be matched with `PublishSubject`. Otherwise it isn't fair for RxSwift. :p

ReactiveSwift is leading in all but the first tests, btw. This might worth investigating. The difference can be attributed to `Signal` always serialising events, whereas `RxSwift.Observable.create` does not. But there seem more to it, given ReactiveKit's performance (pthread mutex is used).

Compiled via Carthage with Xcode 8.3.2. Running on i7 6260U.

| Item | ReactiveSwift | RxSwift | ReactiveKit |
| --- | --- | --- | --- |
| Test 1 | 0.040 s | 0.035 s | 0.030 s |
| Test 2 | 5.055 s | 6.188 s | 6.439 s |
| Test 3 | 8.527 s | 9.429 s | N/A |
| Test 4 | 0.430 s | 0.635 s | N/A |